### PR TITLE
Returns the correct string length

### DIFF
--- a/_printf.c
+++ b/_printf.c
@@ -27,8 +27,8 @@ int _printf(const char *format, ...)
 	{
 		if (format[i] != '%')
 		{
-			c = _write(format[i]);
-			count += c;
+			_write(format[i]);
+			count += 1;
 		}
 		else
 		{
@@ -37,8 +37,8 @@ int _printf(const char *format, ...)
 			{
 				if (*_types[j].specifier == format[i])
 				{
-					_types[j].f(args);
-					count += 1;
+					c = _types[j].f(args);
+					count += c;
 				}
 			j++;
 			}
@@ -46,5 +46,5 @@ int _printf(const char *format, ...)
 		}
 		i++;
 	}
-	return (count);
+	return (count - 1);
 }

--- a/holberton.h
+++ b/holberton.h
@@ -10,12 +10,12 @@
 typedef struct specifiers
 {
 	char *specifier;
-	void (*f)(va_list args);
+	int (*f)(va_list args);
 } spc_dt;
 
 int _write(char c);
 int _printf(const char *format, ...);
-void _print_a_char(va_list args);
+int _print_a_char(va_list args);
 int _print_a_string(va_list args);
 int _validate(const char *str_format);
 

--- a/printers.c
+++ b/printers.c
@@ -5,11 +5,12 @@
   * _print_a_char - Prints a char
   * @args: A list of variadic arguments
   *
-  * Return: Nothing
+  * Return: The length of the character
   */
-void _print_a_char(va_list args)
+int _print_a_char(va_list args)
 {
 	_write(va_arg(args, int));
+	return (1);
 }
 
 /**


### PR DESCRIPTION
This commit returns the correct string
length and changes the data type that
returns each function of printers.c